### PR TITLE
scipy.integrate

### DIFF
--- a/Beginner Level/ScipyIntro.ipynb
+++ b/Beginner Level/ScipyIntro.ipynb
@@ -192,6 +192,84 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. scipy.integrate\n",
+    "Overview: The scipy.integrate sub-package is designed for performing numerical integration (calculating the area under curves) and solving ordinary differential equations (ODEs). It includes both single and multiple integration methods.\n",
+    "\n",
+    "Key Functions:\n",
+    "quad(func, a, b)\n",
+    "\n",
+    "- Computes the definite integral of func from a to b.\n",
+    "- Returns the integral value and an estimate of the absolute error.\n",
+    "- Example: Integrating a Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Integral of f(x) from 0 to 1: 0.3333, Estimated Error: 3.701e-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "from scipy.integrate import quad\n",
+    "\n",
+    "def f(x):\n",
+    "    return x**2\n",
+    "\n",
+    "integral_value, error_estimate = quad(f, 0, 1)\n",
+    "print(f\"Integral of f(x) from 0 to 1: {integral_value:.4f}, Estimated Error: {error_estimate:.4g}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "dblquad(func, a, b, gfun, hfun)\n",
+    "\n",
+    "- Computes a double integral over a rectangular region.\n",
+    "- gfun and hfun define the limits for the inner integral."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Double Integration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Double integral of f(x, y): 0.2500\n"
+     ]
+    }
+   ],
+   "source": [
+    "from scipy.integrate import dblquad\n",
+    "\n",
+    "def f(x, y):\n",
+    "    return x * y\n",
+    "\n",
+    "integral_value = dblquad(f, 0, 1, lambda x: 0, lambda x: 1)\n",
+    "print(f\"Double integral of f(x, y): {integral_value[0]:.4f}\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
The scipy.integrate sub-package is designed for performing numerical integration (calculating the area under curves) and solving ordinary differential equations (ODEs). It includes both single and multiple integration methods.