### PR TITLE
Update SCIPY-INTEGERATE.ipynb

### DIFF
--- a/Beginner Level/SCIPY-INTEGERATE.ipynb
+++ b/Beginner Level/SCIPY-INTEGERATE.ipynb
@@ -49,6 +49,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- `quad()` returns two values: the integral result and the error estimate.\n",
+    "- It integrates `f(x)` from `0` to `2`.\n",
+    "\n",
+    "**Explanation**: Just like in your school where you learned to find the area of rectangles and sum them up to approximate the area under a curve, here SciPy does it smartly for us. The result will be the exact area!"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
- `quad()` returns two values: the integral result and the error estimate.
- It integrates `f(x)` from `0` to `2`.

**Explanation**: Just like in your school where you learned to find the area of rectangles and sum them up to approximate the area under a curve, here SciPy does it smartly for us. The result will be the exact area!