### PR TITLE
### **Double Integration using `dblquad()`**  Now suppose you need to…

### DIFF
--- a/Beginner Level/SCIPY-INTEGERATE.ipynb
+++ b/Beginner Level/SCIPY-INTEGERATE.ipynb
@@ -59,6 +59,49 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Double Integration using `dblquad()`**\n",
+    "\n",
+    "Now suppose you need to calculate a double integral. Don’t worry! You don’t have to do everything by hand—SciPy has your back with **`dblquad()`**. It’s for *two-variable* functions.\n",
+    "\n",
+    "Let’s say you want to integrate `f(x, y) = x * y` over the ranges `x: [0, 1]` and `y: [0, 1]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result of the double integration: 0.24999999999999997\n",
+      "Estimated error: 5.539061329123429e-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "def f(x, y):\n",
+    "    return x * y\n",
+    "\n",
+    "result, error = integrate.dblquad(f, 0, 1, lambda x: 0, lambda x: 1)\n",
+    "\n",
+    "print(\"Result of the double integration:\", result)\n",
+    "print(\"Estimated error:\", error)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- The function `f(x, y)` is integrated over the region where `x` ranges from `0` to `1`, and for each value of `x`, `y` ranges from `0` to `1`.\n",
+    "- We use **lambda functions** here to specify the limits for `y` which depend on `x`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
… calculate a double integral. Don’t worry! You don’t have to do everything by hand—SciPy has your back with **`dblquad()`**. It’s for *two-variable* functions.  Let’s say you want to integrate `f(x, y) = x * y` over the ranges `x: [0, 1]` and `y: [0, 1]`.

- The function `f(x, y)` is integrated over the region where `x` ranges from `0` to `1`, and for each value of `x`, `y` ranges from `0` to `1`.
- We use **lambda functions** here to specify the limits for `y` which depend on `x`.