### PR TITLE
Update SCIPY-SPATIAL.ipynb

### DIFF
--- a/Beginner Level/SCIPY-SPATIAL.ipynb
+++ b/Beginner Level/SCIPY-SPATIAL.ipynb
@@ -487,6 +487,53 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "### **KDTree Query Ball Point and Radius Searches**\n",
+    "\n",
+    "We’ve seen how to search for the nearest neighbors using KDTree, but there’s more! Sometimes, you don’t just want the nearest point—you might want to find all points within a certain radius from a given point. This is called a **radius search**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Points within radius 0.3: [[0.60163177 0.58115573]\n",
+      " [0.42403984 0.35728342]\n",
+      " [0.39377483 0.52596588]\n",
+      " [0.58390111 0.5699406 ]\n",
+      " [0.33613518 0.72583156]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from scipy.spatial import KDTree\n",
+    "import numpy as np\n",
+    "\n",
+    "points = np.random.rand(10, 2)  # Random points\n",
+    "tree = KDTree(points)\n",
+    "query_point = [0.5, 0.5]\n",
+    "radius = 0.3\n",
+    "indices = tree.query_ball_point(query_point, radius)\n",
+    "\n",
+    "print(f\"Points within radius {radius}: {points[indices]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- `query_ball_point()` returns all points within a given **radius** of a query point.\n",
+    "- This is useful when you want to search for points within a specific distance, such as in proximity searches in a map or finding nearby restaurants."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": []
   }
  ],


### PR DESCRIPTION
- `query_ball_point()` returns all points within a given **radius** of a query point.
- This is useful when you want to search for points within a specific distance, such as in proximity searches in a map or finding nearby restaurants.